### PR TITLE
added dependency check for markdown-notices, closes #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 1. [](#bugfix)
     * Fixed ES6 syntax to ES5 compatibility [#10](https://github.com/getgrav/grav-plugin-editor-buttons/issues/10)
+2. [](#bugfix)
+    * Added feature dependency check for markdown-notices [#9](https://github.com/getgrav/grav-plugin-editor-buttons/issues/9)
 
 # v1.1.0-beta.1
 ## 06/05/2016

--- a/editor-buttons.php
+++ b/editor-buttons.php
@@ -35,7 +35,7 @@ class EditorButtonsPlugin extends Plugin
                 || $this->config->get('plugins.editor-buttons.insert_notice.note')
                 || $this->config->get('plugins.editor-buttons.insert_notice.tip');
 
-            if ($this->config->get('plugins.editor-buttons.insert_notice') || $noticesBC) {
+            if ($this->config->get('plugins.markdown-notices.enabled') && $this->config->get('plugins.editor-buttons.insert_notice') || $noticesBC) {
                 $this->grav['assets']->addJs($this->grav['base_url_absolute'] . '/user/plugins/editor-buttons/admin/buttons/insert-notice/js/notices.js');
                 $this->grav['assets']->addCss($this->grav['base_url_absolute'] . '/user/plugins/editor-buttons/admin/buttons/insert-notice/css/button.css');
             }


### PR DESCRIPTION
Added a dependency check for markdown-notices, will not enable notices button if plugin not present
